### PR TITLE
feat(network): Implementa timeouts de inatividade e TCP Keep-Alive

### DIFF
--- a/rs_core/Cargo.lock
+++ b/rs_core/Cargo.lock
@@ -185,6 +185,7 @@ name = "rs_core"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "socket2",
  "tokio",
 ]
 

--- a/rs_core/Cargo.toml
+++ b/rs_core/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
+socket2 = "0.5"

--- a/rs_core/src/network/mod.rs
+++ b/rs_core/src/network/mod.rs
@@ -1,29 +1,33 @@
 // Conteúdo para: rs_core/src/network/mod.rs
 
 use bytes::BytesMut;
+use socket2::{Socket, Domain, Type}; // Importações para o Keep-Alive
 use std::collections::HashMap;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration; // Importação para definir durações de tempo
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout; // Importação da função de timeout
 
-// Tarefa 2: Enum para representar o estado da conexão na nossa aplicação.
+// Tarefa 1: Constante para o timeout de inatividade (ex: 10 segundos)
+const IDLE_TIMEOUT_SECS: u64 = 10;
+// Tarefa 2: Constante para o tempo do TCP Keep-Alive (ex: 60 segundos)
+const TCP_KEEPALIVE_SECS: u64 = 60;
+
+// ... (structs ConnectionState, Connection e type ConnectionMap continuam iguais) ...
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ConnectionState {
     Active,
     ShuttingDown,
 }
-
-// Tarefa 2: Struct para guardar os dados de uma conexão ativa.
 #[derive(Debug, Clone)]
 pub struct Connection {
     pub addr: SocketAddr,
     pub state: ConnectionState,
 }
-
-// Tarefa 2: Atualizamos nosso mapa para armazenar a struct Connection completa.
 type ConnectionMap = Arc<Mutex<HashMap<usize, Connection>>>;
 
 pub async fn run_server() -> Result<(), Box<dyn Error>> {
@@ -35,9 +39,17 @@ pub async fn run_server() -> Result<(), Box<dyn Error>> {
     let connections: ConnectionMap = Arc::new(Mutex::new(HashMap::new()));
 
     loop {
-        // Tarefa 1: O accept() conclui o handshake TCP.
         match listener.accept().await {
             Ok((socket, addr)) => {
+                // Tarefa 2: Configurar o TCP Keep-Alive no socket recém-aceito
+                let socket_ref = socket2::SockRef::from(&socket);
+                let keepalive = socket2::TcpKeepalive::new().with_time(Duration::from_secs(TCP_KEEPALIVE_SECS));
+                if let Err(e) = socket_ref.set_tcp_keepalive(&keepalive) {
+                    eprintln!("[{}] Erro ao configurar Keep-Alive: {}", addr, e);
+                } else {
+                    println!("[{}] TCP Keep-Alive configurado.", addr);
+                }
+
                 println!("Nova conexão de: {}", addr);
                 let connections_clone = Arc::clone(&connections);
                 let counter_clone = Arc::clone(&connection_id_counter);
@@ -60,47 +72,51 @@ async fn handle_connection(
     id_counter: Arc<AtomicUsize>,
 ) {
     let conn_id = id_counter.fetch_add(1, Ordering::SeqCst);
-    
-    // Tarefa 2: Ao aceitar a conexão (pós-handshake), criamos o estado inicial.
-    let new_connection = Connection {
-        addr,
-        state: ConnectionState::Active, // A conexão começa como Ativa.
-    };
+    let new_connection = Connection { addr, state: ConnectionState::Active };
     connections.lock().unwrap().insert(conn_id, new_connection);
     println!("[{}] Conexão estabelecida. Total de conexões: {}", conn_id, connections.lock().unwrap().len());
 
     let mut buffer = BytesMut::with_capacity(1024);
+    let idle_duration = Duration::from_secs(IDLE_TIMEOUT_SECS);
 
     loop {
-        match socket.read_buf(&mut buffer).await {
-            Ok(0) => {
-                println!("[{}] Conexão fechada pelo cliente.", conn_id);
+        // Tarefa 1: Envelopa a operação de leitura com um timeout.
+        let read_operation = socket.read_buf(&mut buffer);
+        
+        match timeout(idle_duration, read_operation).await {
+            // Caso 1: Timeout ocorreu
+            Err(_) => {
+                println!("[{}] Timeout de inatividade. Encerrando conexão.", conn_id);
                 break;
             }
-            Ok(n) => {
-                println!("[{}] {} bytes lidos.", conn_id, n);
-                if let Err(e) = socket.write_all(&buffer).await {
-                    eprintln!("[{}] Erro ao escrever para o socket: {}", conn_id, e);
+            // Caso 2: Operação de leitura completou (com sucesso ou erro)
+            Ok(result) => match result {
+                Ok(0) => {
+                    println!("[{}] Conexão fechada pelo cliente.", conn_id);
                     break;
                 }
-                buffer.clear();
-            }
-            Err(e) => {
-                eprintln!("[{}] Erro ao ler do socket: {}", conn_id, e);
-                break;
+                Ok(n) => {
+                    println!("[{}] {} bytes lidos.", conn_id, n);
+                    if let Err(e) = socket.write_all(&buffer).await {
+                        eprintln!("[{}] Erro ao escrever para o socket: {}", conn_id, e);
+                        break;
+                    }
+                    buffer.clear();
+                }
+                Err(e) => {
+                    eprintln!("[{}] Erro ao ler do socket: {}", conn_id, e);
+                    break;
+                }
             }
         }
     }
-    
-    // Tarefa 3: Implementar fechamento elegante.
-    // Antes de remover do mapa, tentamos um shutdown gracioso do socket.
+
     if let Err(e) = socket.shutdown().await {
         eprintln!("[{}] Erro durante o shutdown do socket: {}", conn_id, e);
     } else {
         println!("[{}] Socket encerrado elegantemente (FIN enviado).", conn_id);
     }
     
-    // Bloco de limpeza final
     connections.lock().unwrap().remove(&conn_id);
     println!("[{}] Conexão removida do mapa. Total de conexões: {}", conn_id, connections.lock().unwrap().len());
 }


### PR DESCRIPTION
Adiciona mecanismos de robustez para gerenciar conexões ociosas ou interrompidas, conforme a Issue #008.

- Implementa um timeout de inatividade no nível da aplicação, utilizando `tokio::time::timeout` para envolver a operação de leitura do socket. Conexões sem atividade são encerradas após um período pré-definido.
- Adiciona a crate `socket2` para configurar a opção `SO_KEEPALIVE` nos sockets TCP no momento da aceitação. Isso permite que o kernel do sistema operacional detecte e feche conexões que foram interrompidas abruptamente (ex: falha de rede).

Closes #008