### PR TITLE
feat(ipc): Define protocolo de serialização com bincode

### DIFF
--- a/rs_core/Cargo.lock
+++ b/rs_core/Cargo.lock
@@ -155,6 +155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1083,7 @@ name = "rs_core"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bincode",
  "bytes",
  "envy",
  "metrics",

--- a/rs_core/Cargo.toml
+++ b/rs_core/Cargo.toml
@@ -20,6 +20,7 @@ tokio-rustls = "0.25"
 rustls-pemfile = "2.1"
 envy = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
 
 # Adicione este bloco inteiro no final do seu Cargo.toml
 [profile.release]

--- a/rs_core/src/bin/test_serialization.rs
+++ b/rs_core/src/bin/test_serialization.rs
@@ -1,0 +1,28 @@
+// Conteúdo para: rs_core/src/bin/test_serialization.rs
+
+// Importa as mensagens que acabamos de definir
+use rs_core::ipc::protocol::LowLevelMessage;
+
+fn main() {
+    println!("--- Teste de Serialização/Desserialização ---");
+
+    // 1. Cria uma instância da nossa mensagem.
+    let original_message = LowLevelMessage::Data {
+        conn_id: 123,
+        data: vec![72, 101, 108, 108, 111], // "Hello" em bytes ASCII
+    };
+    println!("Mensagem Original: {:?}", original_message);
+
+    // 2. Serializa a mensagem para um vetor de bytes usando bincode.
+    let serialized_data = bincode::serialize(&original_message).expect("Falha ao serializar");
+    println!("Dados Serializados ({} bytes): {:?}", serialized_data.len(), serialized_data);
+
+    // 3. Desserializa os bytes de volta para a nossa struct.
+    let deserialized_message: LowLevelMessage = bincode::deserialize(&serialized_data).expect("Falha ao desserializar");
+    println!("Mensagem Desserializada: {:?}", deserialized_message);
+
+    // 4. Verifica se a mensagem original e a desserializada são idênticas.
+    assert_eq!(original_message, deserialized_message);
+
+    println!("\n✅ Teste de round-trip concluído com sucesso!");
+}

--- a/rs_core/src/ipc/mod.rs
+++ b/rs_core/src/ipc/mod.rs
@@ -1,0 +1,3 @@
+// Conteúdo para: rs_core/src/ipc/mod.rs
+
+pub mod protocol;

--- a/rs_core/src/ipc/protocol.rs
+++ b/rs_core/src/ipc/protocol.rs
@@ -1,0 +1,39 @@
+// Conteúdo para: rs_core/src/ipc/protocol.rs
+
+use serde::{Deserialize, Serialize};
+
+// Usamos enums para definir um "protocolo" de mensagens.
+// O #[derive(...)] gera o código para serializar/desserializar automaticamente.
+
+/// Mensagens enviadas do núcleo Rust (baixo nível) para a lógica Python (alto nível).
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum LowLevelMessage {
+    /// Notifica que uma nova conexão foi estabelecida.
+    NewConnection {
+        conn_id: u64,
+        remote_addr: String, // Usamos String para simplicidade na serialização entre linguagens.
+    },
+    /// Envia os dados brutos de uma requisição para serem processados.
+    Data {
+        conn_id: u64,
+        data: Vec<u8>,
+    },
+    /// Informa que o cliente fechou a conexão.
+    ConnectionClosed {
+        conn_id: u64,
+    },
+}
+
+/// Mensagens enviadas da lógica Python (alto nível) para o núcleo Rust (baixo nível).
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum HighLevelMessage {
+    /// Envia os dados de resposta que devem ser escritos de volta para o cliente.
+    ResponseData {
+        conn_id: u64,
+        data: Vec<u8>,
+    },
+    /// Solicita que o núcleo Rust encerre uma conexão específica.
+    CloseConnection {
+        conn_id: u64,
+    },
+}


### PR DESCRIPTION
Implementa o mecanismo de serialização de dados para a comunicação entre as camadas, conforme a Issue #015.

- A crate `bincode` foi escolhida como o formato de serialização binária pela sua performance e simplicidade de uso com `serde`.
- As estruturas de comunicação (enums `LowLevelMessage` e `HighLevelMessage`) foram definidas no novo módulo `ipc::protocol`.
- Um teste de "round-trip" (serialização e desserialização) foi implementado e executado com sucesso, validando a abordagem.