### PR TITLE
feat(security): Implementa políticas e cabeçalhos de segurança HTTP

### DIFF
--- a/py_core/src/handlers/cookie_handler.py
+++ b/py_core/src/handlers/cookie_handler.py
@@ -1,30 +1,21 @@
-# Conteúdo para: py_core/src/handlers/cookie_handler.py
+# Conteúdo final para: py_core/src/handlers/cookie_handler.py
 
 from http.cookies import SimpleCookie
 from typing import Dict, Optional
 
 def parse_cookies(headers: Dict[str, str]) -> Dict[str, str]:
-    """
-    Extrai os cookies do cabeçalho 'cookie' de uma requisição.
-    """
     cookie_header = headers.get('cookie')
     if not cookie_header:
         return {}
-    
     cookie = SimpleCookie()
     cookie.load(cookie_header)
-    
-    # SimpleCookie armazena objetos Morsel, extraímos apenas os valores.
     return {k: v.value for k, v in cookie.items()}
 
 def create_session_cookie(session_id: str) -> str:
-    """
-    Cria o valor para o cabeçalho 'Set-Cookie' para uma nova sessão.
-    """
     cookie = SimpleCookie()
     cookie['session_id'] = session_id
     cookie['session_id']['path'] = '/'
     cookie['session_id']['httponly'] = True
-    # Adicionar 'secure' = True e 'samesite' = 'Lax' ou 'Strict' em produção
-    
+    cookie['session_id']['samesite'] = 'Lax' # Proteção contra CSRF
+    # Em produção, adicione: cookie['session_id']['secure'] = True
     return cookie.output(header='').strip()

--- a/py_core/src/utils/http_response.py
+++ b/py_core/src/utils/http_response.py
@@ -1,3 +1,5 @@
+# Conteúdo final para: py_core/src/utils/http_response.py
+
 from http import HTTPStatus
 from typing import Dict, Optional, List
 
@@ -7,6 +9,10 @@ def build_response(
     set_cookies: Optional[List[str]] = None,
     body: bytes = b''
 ) -> bytes:
+    """
+    Constrói uma resposta HTTP/1.1 completa, incluindo importantes
+    cabeçalhos de segurança por padrão.
+    """
     try:
         status = HTTPStatus(status_code)
         status_line = f"HTTP/1.1 {status.value} {status.phrase}\r\n"
@@ -14,6 +20,16 @@ def build_response(
         status_line = f"HTTP/1.1 {status_code}\r\n"
 
     response_headers = headers or {}
+    
+    # --- ADIÇÃO DOS CABEÇALHOS DE SEGURANÇA ---
+    # Previne Clickjacking
+    response_headers['X-Frame-Options'] = 'DENY'
+    # Previne ataques de MIME sniffing
+    response_headers['X-Content-Type-Options'] = 'nosniff'
+    # Define uma Política de Segurança de Conteúdo (CSP) restritiva
+    response_headers['Content-Security-Policy'] = "default-src 'self'; frame-ancestors 'none';"
+    # -----------------------------------------------
+
     response_headers['Content-Length'] = str(len(body))
     if 'Content-Type' not in response_headers:
         response_headers['Content-Type'] = 'text/plain; charset=utf-8'


### PR DESCRIPTION
Fortalece a segurança da aplicação e documenta as políticas, conforme a Issue #27.

- Adiciona cabeçalhos de segurança HTTP (`X-Frame-Options`, `X-Content-Type-Options`, `Content-Security-Policy`) a todas as respostas através do utilitário `http_response.py`.
- Atualiza o `cookie_handler.py` para incluir o atributo `SameSite=Lax` nos cookies de sessão, mitigando ataques de CSRF.
- Cria o documento `SECURITY.md` para centralizar todas as políticas de segurança do projeto, incluindo regras de firewall (NFTables), diretrizes de banco de dados e as defesas da camada de aplicação.

Closes #027